### PR TITLE
fire an iron event when detached

### DIFF
--- a/demo/simple-form.html
+++ b/demo/simple-form.html
@@ -25,7 +25,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     listeners: {
-      'iron-form-element-register': '_elementRegistered'
+      'iron-form-element-register': '_elementRegistered',
+      'iron-form-element-unregister': '_elementUnregistered'
     },
 
     ready: function() {
@@ -34,7 +35,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     _elementRegistered: function(e) {
       this.formElements.push(e.target);
-      this.fire('element-registered');
+    },
+
+    _elementUnregistered: function(e) {
+      var target = e.detail.target;
+      if (target) {
+        var index = this.formElements.indexOf(target);
+        if (index > -1) {
+          this.formElements.splice(index, 1);
+        }
+      }
     }
 
   });

--- a/iron-form-element-behavior.html
+++ b/iron-form-element-behavior.html
@@ -15,15 +15,26 @@ Enables a custom element to be included in an `iron-form`.
 -->
 <script>
 
-  /** 
-  
+  /**
+
   @demo demo/index.html
-  @polymerBehavior 
-  
+  @polymerBehavior
+
   */
   Polymer.IronFormElementBehavior = {
 
     properties: {
+      /**
+       * Fired when the element is added to an `iron-form`.
+       *
+       * @event iron-form-element-register
+       */
+
+      /**
+       * Fired when the element is removed from an `iron-form`.
+       *
+       * @event iron-form-element-unregister
+       */
 
       /**
        * The name of this element.
@@ -39,10 +50,25 @@ Enables a custom element to be included in an `iron-form`.
         notify: true,
         type: String
       },
+
+      /**
+       * Need to keep a reference to the form this element is registered
+       * to, so that it can unregister if detached.
+       */
+      _parentForm: {
+        type: Object
+      }
     },
 
     attached: function() {
+      this._parentForm = Polymer.dom(this).parentNode;
       this.fire('iron-form-element-register');
+    },
+
+    detached: function() {
+      if (this._parentForm) {
+        this._parentForm.fire('iron-form-element-unregister', {target: this});
+      }
     }
 
   };


### PR DESCRIPTION
Adds an 'iron-form-element-unregistered` event that fires when the element is detached. Fixes https://github.com/PolymerElements/iron-form-element-behavior/issues/5

The full fix requires the event to be handled by the `iron-form`: https://github.com/PolymerElements/iron-form/pull/21
