### PR TITLE
form elements can have the required attribute

### DIFF
--- a/iron-form-element-behavior.html
+++ b/iron-form-element-behavior.html
@@ -49,6 +49,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       /**
+       * Set to true to mark the input as required. If used in a form, a
+       * custom element that uses this behavior should also use
+       * Polymer.IronValidatableBehavior and define a custom validation method.
+       * Otherwise, a `required` element will always be considered valid.
+       * It's also strongly recomended to provide a visual style for the element
+       * when it's value is invalid.
+       */
+      required: {
+        type: Boolean,
+        value: false
+      },
+
+      /**
        * The form that the element is registered to.
        */
       _parentForm: {


### PR DESCRIPTION
This would allow custom elements to automagically get this attribute. Note that if they don't have a `validate()` method (i.e. from `IronValidatableBehavior`), this won't actually do anything.

/cc @cdata @morethanreal 
