### PR TITLE
Adds `valueForFormSerialization` method.

### DIFF
--- a/iron-form-element-behavior.html
+++ b/iron-form-element-behavior.html
@@ -79,8 +79,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (this._parentForm) {
         this._parentForm.fire('iron-form-element-unregister', {target: this});
       }
-    }
+    },
 
+    valueForFormSerialization: function() {
+      return this.value;
+    }
   };
 
 </script>


### PR DESCRIPTION
Part of a fix for PolymerElements/paper-toggle-button#66.
