### PR TITLE
stop bringing in the paper-styles kitchen sink

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,8 +22,10 @@
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
-    "paper-styles": "PolymerElements/paper-styles#^1.0.0"
+    "paper-styles": "PolymerElements/paper-styles#^1.0.0",
+    "test-fixture": "PolymerElements/test-fixture#^1.0.0",
+    "web-component-tester": "polymer/web-component-tester#^3.4.0",
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
   },
   "ignore": []
 }

--- a/bower.json
+++ b/bower.json
@@ -22,8 +22,6 @@
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-    "test-fixture": "PolymerElements/test-fixture#^1.0.0",
-    "web-component-tester": "*",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
     "paper-styles": "PolymerElements/paper-styles#^1.0.0"
   },

--- a/demo/index.html
+++ b/demo/index.html
@@ -19,7 +19,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
-    <link rel="stylesheet" href="../../paper-styles/paper-styles.html">
     <link rel="import" href="../../paper-styles/demo-pages.html">
     <link rel="import" href="simple-form.html">
     <link rel="import" href="simple-element.html">

--- a/test/basic.html
+++ b/test/basic.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <title>iron-form-element-behavior</title>
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+
+  <link rel="import" href="../../polymer/polymer.html">
+  <link rel="import" href="../iron-form-element-behavior.html">
+  <link rel="import" href="simple-element.html">
+  <link rel="import" href="simple-form.html">
+</head>
+<body>
+
+  <test-fixture id="basic">
+    <template>
+      <form is="simple-form"></form>
+    </template>
+  </test-fixture>
+
+  <script>
+    suite('basic', function() {
+      var form;
+
+      setup(function() {
+        form = fixture('basic');
+      });
+
+      test('elements fire an event when attached', function(done) {
+        var element = document.createElement('input', 'simple-element');
+
+        var handler = sinon.spy();
+        form.addEventListener('iron-form-element-register', handler);
+
+        form.appendChild(element);
+        Polymer.Base.async(function() {
+          expect(handler.callCount).to.be.equal(1);
+          done();
+        }, 1);
+      });
+
+      test('elements fire an event when detached', function(done) {
+        var element = document.createElement('input', 'simple-element');
+        form.appendChild(element);
+        element._parentForm = form;
+
+        var handler = sinon.spy();
+        form.addEventListener('iron-form-element-unregister', handler);
+
+        form.removeChild(element);
+        Polymer.Base.async(function() {
+          expect(handler.callCount).to.be.equal(1);
+          done();
+        }, 1);
+      });
+  });
+
+  </script>
+
+</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <script src="../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../web-component-tester/browser.js"></script>
+  </head>
+  <body>
+    <script>
+      WCT.loadSuites([
+        'basic.html'
+      ]);
+    </script>
+  </body>
+</html>

--- a/test/simple-element.html
+++ b/test/simple-element.html
@@ -1,0 +1,23 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../iron-form-element-behavior.html">
+
+<script>
+
+  Polymer({
+    is: 'simple-element',
+    extends: 'input',
+    behaviors: [
+      Polymer.IronFormElementBehavior
+    ]
+  });
+
+</script>

--- a/test/simple-form.html
+++ b/test/simple-form.html
@@ -1,0 +1,19 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<link rel="import" href="../../polymer/polymer.html">
+
+<script>
+
+  Polymer({
+    is: 'simple-form',
+    extends: 'form'
+  });
+
+</script>


### PR DESCRIPTION
Fixes the generic usage of `paper-styles.html` and `/deep/` classes and uses the specific imports instead. 

This doesn't have any tests (because it's just adding a property and fires an event), so I removed testing things from bower.
