### PR TITLE
Set type of value to any for typescript compilation

### DIFF
--- a/iron-form-element-behavior.d.ts
+++ b/iron-form-element-behavior.d.ts
@@ -18,7 +18,7 @@ declare namespace Polymer {
    *
    *   Events `iron-form-element-register` and `iron-form-element-unregister` are not fired on Polymer 2.0.
    *
-   *
+   *   
    */
   interface IronFormElementBehavior {
 

--- a/iron-form-element-behavior.d.ts
+++ b/iron-form-element-behavior.d.ts
@@ -18,7 +18,7 @@ declare namespace Polymer {
    *
    *   Events `iron-form-element-register` and `iron-form-element-unregister` are not fired on Polymer 2.0.
    *
-   *   
+   *
    */
   interface IronFormElementBehavior {
 
@@ -30,7 +30,7 @@ declare namespace Polymer {
     /**
      * The value for this element.
      */
-    value: any;
+    value: string|number|null|undefined;
 
     /**
      * Set to true to mark the input as required. If used in a form, a

--- a/iron-form-element-behavior.d.ts
+++ b/iron-form-element-behavior.d.ts
@@ -30,7 +30,7 @@ declare namespace Polymer {
     /**
      * The value for this element.
      */
-    value: string|null|undefined;
+    value: any;
 
     /**
      * Set to true to mark the input as required. If used in a form, a

--- a/iron-form-element-behavior.html
+++ b/iron-form-element-behavior.html
@@ -44,9 +44,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       /**
        * The value for this element.
+       * @type {string|number|null|undefined}
        */
       value: {
-        notify: true
+        notify: true,
+        type: String
       },
 
       /**

--- a/iron-form-element-behavior.html
+++ b/iron-form-element-behavior.html
@@ -34,7 +34,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *
        * @event iron-form-element-unregister
        */
-       
+
       /**
        * The name of this element.
        */
@@ -46,8 +46,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * The value for this element.
        */
       value: {
-        notify: true,
-        type: String
+        notify: true
       },
 
       /**


### PR DESCRIPTION
The type of the value is not required in this behavior per se. Moreover, it is wrong to state it is a `string`, as it is a `number` in other cases (for example `paper-slider`).

Fixes https://github.com/Polymer/gen-typescript-declarations/issues/103